### PR TITLE
Attempt to fix RTL layout

### DIFF
--- a/browser/style/style.css
+++ b/browser/style/style.css
@@ -3,6 +3,9 @@
   margin: 0;
   padding: 0;
 }
+*[lang="ar"] {
+  direction: rtl;
+}
 body {
   font-family: Roboto, sans-serif;
 }
@@ -67,6 +70,10 @@ a {
   z-index: 50;
   width: 45;
 }
+html[lang="ar"] #second_nav_img {
+  right: auto;
+  left: 30px;
+}
 .content {
   padding: 30;
   position: absolute;
@@ -92,6 +99,12 @@ a {
   margin-bottom: 40;
   position: relative;
   margin-left: -30%;
+}
+html[lang="ar"] #laptop {
+  margin-right: -30%;
+  margin-left: 80px;
+  left: auto;
+  right: 50%;
 }
 .feature {
   padding-top: 130px;
@@ -217,6 +230,10 @@ h3 {
   font-family: Hack;
   padding-bottom: 5;
 }
+html[lang="ar"] .code {
+  direction: ltr;
+  text-align: left;
+}
 #download_section p a {
   color: lightgrey;
 }
@@ -259,6 +276,9 @@ h3 {
   margin: 5 0;
   color: #37474F;
   margin-bottom: 10.;
+}
+html[lang="ar"] .card .description {
+  text-align: right;
 }
 .card .social {
   list-style-type: none;
@@ -686,6 +706,9 @@ h3 {
     width: 95%;
     width: calc(100% - 20px);
   }
+  html[lang="ar"] .card {
+    text-align: right;
+  }
   #laptop {
     margin-top: 40;
   }
@@ -698,6 +721,9 @@ h3 {
   }
   #code_section {
     padding: 30 30;
+  }
+  html[lang="ar"] #code_section {
+    text-align: right;
   }
   .feature {
     padding-top: 130px;


### PR DESCRIPTION
Attempt N.1
This is the code I used in Stylish:

```
@namespace url(http://www.w3.org/1999/xhtml);

@-moz-document domain("liriproject.me") {
  html[lang="ar"] {
    direction: rtl;
  }
  html[lang="ar"] .txlive-langselector.txlive-langselector-bottomright {
    left: 0px;
    right: auto;
  }
  html[lang="ar"] .txlive-langselector .txlive-langselector-current {
    float: right;
  }
  html[lang="ar"] .txlive-langselector .txlive-langselector-marker {
    float: left;
  }
  html[lang="ar"] #second_nav_img {
    right: auto;
    left: 30px;
  }
  html[lang="ar"] #laptop {
    margin-right: -30%;
    margin-left: 80px;
    left: auto;
    right: 50%;
  }
  html[lang="ar"] .code {
    direction: ltr;
    text-align: left;
  }
  html[lang="ar"] #code_section, .card .description, .card {
    text-align: right;
  }
}
```

It would be better if (dir="rtl") is in the head of the document.
