### PR TITLE
removed unnecessarily link to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 		</ul>
 	  </div>
 	  <div id="liri-browser">
-	  	<span><a href="browser/index.html">LIRI BROWSER</a></span>
+	  	<span><a href="browser/">LIRI BROWSER</a></span>
 	  </div>
 		<script src="js/script.js"></script>
 	</body>


### PR DESCRIPTION
there's no need to add index.html in the link, the browser finds that out
automatically
